### PR TITLE
Make things work in v3_core

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd release/tests/test_server
 $ERL_TOP/tests_install/bin/erl
 
 ts:install().
-ts:run(stdlib, [erl_scan_SUITE, erl_lint_SUITE]).
+ts:run(stdlib, [erl_scan_SUITE, erl_lint_SUITE, begin_maybe_SUITE]).
 ts:run(syntax_tools, [syntax_tools_SUITE]).
 % ts:run(stdlib, [batch]). % this takes many minutes to run and tests a lot of unrelated stuff
 % ts:run(compiler, [batch]). % requires a bunch of external deps and remote displays?
@@ -54,14 +54,7 @@ ts:run(syntax_tools, [syntax_tools_SUITE]).
 Re-runing tests after requires re-building things and starting afresh. You may have to delete the .beam files you modified to get the rebuild step to work.
 
 ```bash
-rm -rf tests_install/lib/erlang/lib/stdlib-3.15.2/ebin/* tests_install/lib/erlang/lib/syntax_tools-2.6/ebin/*
-
-## Then this can be run in one copy/paste
-./otp_build setup -a --prefix=$PWD/tests_install
-make install
-./otp_build tests
-cd release/tests/test_server
-$ERL_TOP/tests_install/bin/erl -eval 'ts:install(), ts:run(stdlib, [erl_scan_SUITE, erl_lint_SUITE]), ts:run(syntax_tools, [syntax_tools_SUITE]), init:stop().'
 cd $ERL_TOP
+rm -rf tests_install/lib/erlang/lib/stdlib-3.15.2/ebin/* tests_install/lib/erlang/lib/syntax_tools-2.6/ebin/*
 ```
 

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -911,7 +911,7 @@ maybe_exprs([{maybe,L,P0,E0}|Es0], St0, Cs0) ->
     %%   b) create the sub-case expression for it
     SubCase = case Cs0 of
         [] -> Pat;
-        _ -> {'case', L, Pat, Cs0}
+        _ -> {cond_case, L, Pat, Cs0}
     end,
     %%   c) assemble in a full clause
     BadClause = {clause,L,[Pat],[],[SubCase]},

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -1603,8 +1603,11 @@ macro_arg([{'receive',Lr}|Toks], E, Arg) ->
     macro_arg(Toks, ['end'|E], [{'receive',Lr}|Arg]);
 macro_arg([{'try',Lr}|Toks], E, Arg) ->
     macro_arg(Toks, ['end'|E], [{'try',Lr}|Arg]);
-macro_arg([{'cond',Lr}|Toks], E, Arg) ->
-    macro_arg(Toks, ['end'|E], [{'cond',Lr}|Arg]);
+%% skip the `cond ... end' blocks since they're used for the
+%% `begin ... cond ... end' blocks temporarily, and matching on
+%% until the end in a macro breaks all parsing.
+%macro_arg([{'cond',Lr}|Toks], E, Arg) ->
+%    macro_arg(Toks, ['end'|E], [{'cond',Lr}|Arg]);
 macro_arg([{Rb,Lrb}|Toks], [Rb|E], Arg) ->	%Found matching close
     macro_arg(Toks, E, [{Rb,Lrb}|Arg]);
 macro_arg([T|Toks], E, Arg) ->

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -414,6 +414,10 @@ expr({match,Anno,P0,E0}, St0) ->
     {E,St1} = expr(E0, St0),
     {P,St2} = pattern(P0, St1),
     {{match,Anno,P,E},St2};
+expr({maybe,Anno,P0,E0}, St0) ->
+    {E,St1} = expr(E0, St0),
+    {P,St2} = pattern(P0, St1),
+    {{maybe,Anno,P,E},St2};
 expr({op,Anno,'not',A0}, St0) ->
     {A,St1} = bool_operand(A0, St0),
     {{op,Anno,'not',A},St1};

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -9,6 +9,7 @@ MODULES= \
 	array_SUITE \
 	base64_SUITE \
 	beam_lib_SUITE \
+	begin_maybe_SUITE \
 	binary_module_SUITE \
 	binref \
 	c_SUITE \

--- a/lib/stdlib/test/begin_maybe_SUITE.erl
+++ b/lib/stdlib/test/begin_maybe_SUITE.erl
@@ -3,10 +3,10 @@
 -include_lib("stdlib/include/assert.hrl").
 
 -export([all/0]).
--export([begin1/1, begin2/1, begin3/1, begin4/1]).
+-export([begin1/1, begin2/1, begin3/1, begin4/1, begin5/1]).
 
 all() ->
-    [begin1, begin2, begin3, begin4].
+    [begin1, begin2, begin3, begin4, begin5].
 
 begin1(_Config) ->
     ?assertEqual(maybe1(), case1()).
@@ -137,9 +137,107 @@ case4() ->
             end
     end.
 
+begin5(_Config) ->
+    ?assertEqual(maybe5(4), case5(4)),
+    ?assertEqual(maybe5(5), case5(5)),
+    ?assertEqual(maybe5(a), case5(b)),
+    {{maybe5(4), case5(4)},
+     {maybe5(5), case5(5)},
+     {maybe5(a), case5(a)}}.
 
+maybe5(A) ->
+    begin
+        {ok, B} <- id({ok,4}),                                      %% B
+        {ok, C=[_|_]} <- {ok, append(A,B)},                         %% C
+        {error, _} <- begin                                         %% D <- E
+                  D = {A,B,C},                                      %% F
+                  {error, _} <- err(D)                              %% G
+              end,
+        ok <- begin                                                 %% H <- I
+                  {error, expected} <- good(D) % D still in scope   %% J
+              cond
+                  ok -> ok                                          %% K
+              end,
+        {ok, {A,B,C}}                                               %% L
+    cond
+        %% TODO: the linter complains here, and it's wrong!
+        {error, expected} -> saved;                                 %% M
+        {error, Unexpected} -> Unexpected;                          %% N
+        {ok, _Unexpected} -> error                                  %% O
+    end.
+
+case5(A) ->
+    case begin
+         case id({ok,4}) of
+             {ok, B} ->                                                 %% B
+                 case {ok,append(A,B)} of
+                     {ok, C=[_|_]} ->                                   %% C
+                         case                                           %% D
+                             case begin                                 %% E
+                                    D = {A,B,C},                        %% F
+                                    case err(D) of                      %% G
+                                        {error, _}=V ->
+                                            {value, V};
+                                        OtherG ->
+                                            {'else', OtherG}
+                                    end
+                             end of                                     %% E (still)
+                                 %% no cond clause, return both flows, no errors possible
+                                 {value, Ve} -> Ve;
+                                 {'else', Ve} -> Ve
+                             end
+                         of                                             %% D (still)
+                             {error, _} ->
+                                 case                                   %% H
+                                     case begin                         %% I
+                                        case good(D) of                 %% J
+                                            {error, expected} = Vj -> {value, Vj};
+                                            Other -> {'else', Other}
+                                        end
+                                     end of
+                                         {value, Vk} -> Vk;
+                                         {'else', ok} -> ok;            %% K
+                                         ElseErr -> erlang:error({cond_clause, ElseErr})
+                                     end
+                                 of
+                                     ok ->
+                                         {value, {ok,{A,B,C}}};         %% L
+                                     OtherL ->
+                                        {'else', OtherL}
+                                end;
+                            Other ->
+                                {'else', Other}
+                        end;
+                    Other ->
+                        {'else', Other}
+                end;
+            Other ->
+                {'else', Other}
+        end
+end of
+    %% good clause
+    {value, X} -> X; % L
+    %% else clause
+    {'else', X} ->
+        case X of
+            {error, expected} -> saved;        % M
+            {error, Unexpected} -> Unexpected; % N
+            {ok, _Unexpected} -> error;        % O
+            ElseErrN -> erlang:error({else_clause, ElseErrN})
+            end
+    end.
 
 %%% HELPERS %%%
 id(X) -> X.
+
 ok({ok, X}) -> X.
+
 append(A,B) -> [A,B].
+
+err({X,_,_}) when is_atom(X) -> {error, bad_type};
+err(_) -> {error, unexpected}.
+
+good({X,X,[X,X]}) ->
+    ok;
+good(_) ->
+    {error, expected}.

--- a/lib/stdlib/test/begin_maybe_SUITE.erl
+++ b/lib/stdlib/test/begin_maybe_SUITE.erl
@@ -1,0 +1,111 @@
+-module(begin_maybe_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([begin1/1, begin2/1, begin3/1]).
+
+all() ->
+    [begin1, begin2].
+
+begin1(_Config) ->
+    ?assertEqual(maybe1(), case1()).
+
+maybe1() ->
+    begin
+        {ok, A} <- id({ok,5}),
+        B = ok(A),
+        {ok, C=[_|_]} <- id({ok, append(A,B)}),
+        {ok, {A,B,C}}
+    cond
+        {error, _Unexpected} -> error;
+        {ok, _Unexpected} -> error
+    end.
+
+case1() ->
+    case begin
+        case id({ok,5}) of
+            {ok, A} ->
+                B = ok(A),
+                case id({ok, append(A,B)}) of
+                    {ok, C=[_|_]} ->
+                        {value, {ok, {A,B,C}}};
+                    Other ->
+                        {'else', Other}
+                end;
+            Other ->
+                {'else', Other}
+        end
+    end of
+        %% good clause
+        {value, X} -> X;
+        %% else clause
+        {'else', X} ->
+            case X of
+                {error, _Unexpected} -> error;
+                {ok, _Unexpected} -> error
+            end
+    end.
+
+begin2(_Config) ->
+    ?assertEqual(maybe2(), case2()).
+
+maybe2() ->
+    begin
+        {ok, A} <- id({ok,5}),
+        B = ok(A),
+        C=[_|_] <- append(A,B),
+        {ok, {A,B,C}}
+    cond
+        {error, _Unexpected} -> error;
+        {ok, _Unexpected} -> error
+    end.
+
+case2() ->
+    case begin
+        case id({ok,5}) of
+            {ok, A} ->
+                B = ok(A),
+                case append(A,B) of
+                    C=[_|_] ->
+                        {value, {ok, {A,B,C}}};
+                    Other ->
+                        {'else', Other}
+                end;
+            Other ->
+                {'else', Other}
+        end
+    end of
+        %% good clause
+        {value, X} -> X;
+        %% else clause
+        {'else', X} ->
+            case X of
+                {error, _Unexpected} -> error;
+                {ok, _Unexpected} -> error
+            end
+    end.
+
+begin3(_Config) ->
+    %% These don't work yet because of macro processing woes or something?
+    % ?assertEqual(x, begin _ <- x end),
+    % ?assertEqual(x, begin _ <- x cond _ -> y end),
+    % ?assertEqual(y, begin nomatch <- x cond _ -> y end),
+    % ?assertEqual(y, begin nomatch <- x cond _ -> x, y end),
+    R1 = begin _ <- x end,
+    ?assertEqual(x, R1),
+    R2 = begin _ <- x cond _ -> y end,
+    ?assertEqual(x, R2),
+    R3 = begin nomatch <- x cond _ -> y end,
+    ?assertEqual(y, R3),
+    R4 = begin nomatch <- x cond _ -> x, y end,
+    ?assertEqual(y, R4),
+    ok.
+
+
+
+
+%%% HELPERS %%%
+id(X) -> X.
+ok({ok, X}) -> X.
+append(A,B) -> [A,B].

--- a/lib/stdlib/test/begin_maybe_SUITE.erl
+++ b/lib/stdlib/test/begin_maybe_SUITE.erl
@@ -9,12 +9,13 @@ all() ->
     [begin1, begin2, begin3, begin4, begin5].
 
 begin1(_Config) ->
-    ?assertEqual(maybe1(), case1()).
+    ?assertEqual(maybe1(), case1()),
+    ok.
 
 maybe1() ->
     begin
         {ok, A} <- id({ok,5}),
-        B = ok(A),
+        B = ok({ok,A}),
         {ok, C=[_|_]} <- id({ok, append(A,B)}),
         {ok, {A,B,C}}
     cond
@@ -26,7 +27,7 @@ case1() ->
     case begin
         case id({ok,5}) of
             {ok, A} ->
-                B = ok(A),
+                B = ok({ok,A}),
                 case id({ok, append(A,B)}) of
                     {ok, C=[_|_]} ->
                         {value, {ok, {A,B,C}}};
@@ -48,12 +49,13 @@ case1() ->
     end.
 
 begin2(_Config) ->
-    ?assertEqual(maybe2(), case2()).
+    ?assertEqual(maybe2(), case2()),
+    ok.
 
 maybe2() ->
     begin
         {ok, A} <- id({ok,5}),
-        B = ok(A),
+        B = ok({ok,A}),
         C=[_|_] <- append(A,B),
         {ok, {A,B,C}}
     cond
@@ -65,7 +67,7 @@ case2() ->
     case begin
         case id({ok,5}) of
             {ok, A} ->
-                B = ok(A),
+                B = ok({ok,A}),
                 case append(A,B) of
                     C=[_|_] ->
                         {value, {ok, {A,B,C}}};

--- a/lib/stdlib/test/begin_maybe_SUITE.erl
+++ b/lib/stdlib/test/begin_maybe_SUITE.erl
@@ -87,12 +87,12 @@ case2() ->
     end.
 
 begin3(_Config) ->
-    %% These don't work yet because of macro processing woes or something?
-    %% seems to be the ??EXPR format dying
-    % ?assertEqual(x, begin _ <- x end),
-    % ?assertEqual(x, begin _ <- x cond _ -> y end),
-    % ?assertEqual(y, begin nomatch <- x cond _ -> y end),
-    % ?assertEqual(y, begin nomatch <- x cond _ -> x, y end),
+    %% These only work if `epp' is modified not to delimit
+    %% `cond ... end' blocks the way they were originally intended.
+    ?assertEqual(x, begin _ <- x end),
+    ?assertEqual(x, begin _ <- x cond _ -> y end),
+    ?assertEqual(y, begin nomatch <- x cond _ -> y end),
+    ?assertEqual(y, begin nomatch <- x cond _ -> x, y end),
     R1 = begin _ <- x end,
     ?assertEqual(x, R1),
     R2 = begin _ <- x cond _ -> y end,

--- a/lib/stdlib/test/begin_maybe_SUITE.erl
+++ b/lib/stdlib/test/begin_maybe_SUITE.erl
@@ -88,6 +88,7 @@ case2() ->
 
 begin3(_Config) ->
     %% These don't work yet because of macro processing woes or something?
+    %% seems to be the ??EXPR format dying
     % ?assertEqual(x, begin _ <- x end),
     % ?assertEqual(x, begin _ <- x cond _ -> y end),
     % ?assertEqual(y, begin nomatch <- x cond _ -> y end),
@@ -100,6 +101,25 @@ begin3(_Config) ->
     ?assertEqual(y, R3),
     R4 = begin nomatch <- x cond _ -> x, y end,
     ?assertEqual(y, R4),
+    R5 = begin begin nomatch <- x cond _ -> x, y end end,
+    ?assertEqual(y, R5),
+    R6 = (fun() -> begin nomatch <- x cond _ -> x, y end end)(),
+    ?assertEqual(y, R6),
+    %% This is equiv to assertequal
+    begin
+        ((fun () ->
+            X__X = (x),
+            case (begin _ <- x end) of
+                X__X -> ok;
+                X__V -> erlang:error({assertEqual,
+                                     [{module, ?MODULE},
+                                      {line, ?LINE},
+                                      {expression, skipped_macro},
+                                      {expected, X__X},
+                                      {value, X__V}]})
+            end
+          end)())
+    end,
     ok.
 
 


### PR DESCRIPTION
This uses the mechanism we discussed, and adds a few tests.

Temporarily skips processing `cond ... end` in `epp` since we don't use it as a standalone block, but that could change if we go for `begin ... catch ... end` instead.