### PR TITLE
Switch from 'cond' to 'catch' in maybe clauses

### DIFF
--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -1603,11 +1603,8 @@ macro_arg([{'receive',Lr}|Toks], E, Arg) ->
     macro_arg(Toks, ['end'|E], [{'receive',Lr}|Arg]);
 macro_arg([{'try',Lr}|Toks], E, Arg) ->
     macro_arg(Toks, ['end'|E], [{'try',Lr}|Arg]);
-%% skip the `cond ... end' blocks since they're used for the
-%% `begin ... cond ... end' blocks temporarily, and matching on
-%% until the end in a macro breaks all parsing.
-%macro_arg([{'cond',Lr}|Toks], E, Arg) ->
-%    macro_arg(Toks, ['end'|E], [{'cond',Lr}|Arg]);
+macro_arg([{'cond',Lr}|Toks], E, Arg) ->
+    macro_arg(Toks, ['end'|E], [{'cond',Lr}|Arg]);
 macro_arg([{Rb,Lrb}|Toks], [Rb|E], Arg) ->	%Found matching close
     macro_arg(Toks, E, [{Rb,Lrb}|Arg]);
 macro_arg([T|Toks], E, Arg) ->

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -55,7 +55,7 @@ Terminals
 char integer float atom string var
 
 '(' ')' ',' '->' '{' '}' '[' ']' '|' '||' '<-' ';' ':' '#' '.'
-'after' 'begin' 'cond' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when'
+'after' 'begin' 'case' 'try' 'catch' 'end' 'fun' 'if' 'of' 'receive' 'when'
 'andalso' 'orelse'
 'bnot' 'not'
 '*' '/' 'div' 'rem' 'band' 'and'
@@ -403,7 +403,7 @@ if_clause -> guard clause_body :
 	{clause,first_anno(hd(hd('$1'))),[],'$1','$2'}.
 
 begin_expr -> 'begin' maybe_exprs 'end' : {block,?anno('$1'),'$2'}.
-begin_expr -> 'begin' maybe_exprs 'cond' cr_clauses 'end':
+begin_expr -> 'begin' maybe_exprs 'catch' cr_clauses 'end':
 	{block,?anno('$1'),'$2', '$4'}.
 
 maybe_expr -> expr : '$1'.

--- a/lib/stdlib/test/begin_maybe_SUITE.erl
+++ b/lib/stdlib/test/begin_maybe_SUITE.erl
@@ -18,7 +18,7 @@ maybe1() ->
         B = ok({ok,A}),
         {ok, C=[_|_]} <- id({ok, append(A,B)}),
         {ok, {A,B,C}}
-    cond
+    catch
         {error, _Unexpected} -> error;
         {ok, _Unexpected} -> error
     end.
@@ -59,7 +59,7 @@ maybe2() ->
         B = ok({ok,A}),
         C=[_|_] <- append(A,B),
         {ok, {A,B,C}}
-    cond
+    catch
         {error, _Unexpected} -> error;
         {ok, _Unexpected} -> error
     end.
@@ -92,11 +92,11 @@ case2() ->
 
 begin3(_Config) ->
     %% These only work if `epp' is modified not to delimit
-    %% `cond ... end' blocks the way they were originally intended.
+    %% `catch ... end' blocks the way they were originally intended.
     ?assertEqual(x, begin _ <- x end),
-    ?assertEqual(x, begin _ <- x cond _ -> y end),
-    ?assertEqual(y, begin nomatch <- x cond _ -> y end),
-    ?assertEqual(y, begin nomatch <- x cond _ -> x, y end),
+    ?assertEqual(x, begin _ <- x catch _ -> y end),
+    ?assertEqual(y, begin nomatch <- x catch _ -> y end),
+    ?assertEqual(y, begin nomatch <- x catch _ -> x, y end),
     ok.
 
 begin4(_Config) ->
@@ -110,7 +110,7 @@ maybe4() ->
         B = ok({ok, A}),
         {ok, C=[_|_]} <- append(A,B),
         {ok, {A,B,C}}
-    cond
+    catch
         {error, _Unexpected} -> error;
         {ok, _Unexpected} -> error
     end.
@@ -137,7 +137,7 @@ case4() ->
             case X of
                 {error, _Unexpected} -> error;
                 {ok, _Unexpected} -> error;
-                ElseErr -> erlang:error({cond_clause, ElseErr})
+                ElseErr -> erlang:error({catch_clause, ElseErr})
             end
     end.
 
@@ -159,11 +159,11 @@ maybe5(A) ->
               end,
         ok <- begin                                                 %% H <- I
                   {error, expected} <- good(D) % D still in scope   %% J
-              cond
+              catch
                   ok -> ok                                          %% K
               end,
         {ok, {A,B,C}}                                               %% L
-    cond
+    catch
         %% TODO: the linter complains here, and it's wrong!
         {error, expected} -> saved;                                 %% M
         {error, Unexpected} -> Unexpected;                          %% N
@@ -186,7 +186,7 @@ case5(A) ->
                                             {'else', OtherG}
                                     end
                              end of                                     %% E (still)
-                                 %% no cond clause, return both flows, no errors possible
+                                 %% no catch clause, return both flows, no errors possible
                                  {value, Ve} -> Ve;
                                  {'else', Ve} -> Ve
                              end
@@ -201,7 +201,7 @@ case5(A) ->
                                      end of
                                          {value, Vk} -> Vk;
                                          {'else', ok} -> ok;            %% K
-                                         ElseErr -> erlang:error({cond_clause, ElseErr})
+                                         ElseErr -> erlang:error({catch_clause, ElseErr})
                                      end
                                  of
                                      ok ->
@@ -227,7 +227,7 @@ end of
             {error, expected} -> saved;        % M
             {error, Unexpected} -> Unexpected; % N
             {ok, _Unexpected} -> error;        % O
-            ElseErrN -> erlang:error({else_clause, ElseErrN})
+            ElseErrN -> erlang:error({catch_clause, ElseErrN})
             end
     end.
 
@@ -242,7 +242,7 @@ maybe6() ->
         {error, expected} <- {ok, 3},
         id(Z),
         X+Z
-    cond
+    catch
         {error, _} -> a;
         {ok, _} -> b
     end.
@@ -279,8 +279,10 @@ begin7(_) ->
 
 maybe7() ->
     begin
-        3
-    cond
+        3,
+        try 1/0 catch _:_ -> ok end,
+        catch 3
+    catch
         {error, _} -> a;
         {ok, _} -> b
     end.


### PR DESCRIPTION
This works fine, and uses a more intuitive format than using 'cond'.

Built upon fh/hoist-core

Not to be merged, more of a demo of how the switch can be done if we pick a different keyword.